### PR TITLE
Move faker gem out of development/test dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'aws-sdk-s3'
 gem 'factory_bot_rails'
+gem 'faker'
 gem 'faraday'
 gem 'figaro'
 gem 'graphql'
@@ -37,7 +38,6 @@ gem 'graphql'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'faker'
   gem 'pry'
   gem 'rspec-rails'
   gem 'shoulda-matchers'


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Move faker gem out of development/test dependency (so that the seed file will hopefully run in production)