### PR TITLE
Rescue  ActiveRecord::RecordNotFound and raise GraphQL::ExecutionError in user / dog queries

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -14,7 +14,11 @@ module Types
     end
 
     def user(id:)
-      User.find(id)
+      begin
+        User.find(id)
+      rescue ActiveRecord::RecordNotFound => e
+        raise GraphQL::ExecutionError, e.message
+      end
     end
 
     # Dog Queries
@@ -59,7 +63,11 @@ module Types
     end
 
     def dog(id:)
-      Dog.find(id)
+      begin
+        Dog.find(id)
+      rescue ActiveRecord::RecordNotFound => e
+        raise GraphQL::ExecutionError, e.message
+      end
     end
   end
 end

--- a/spec/graphql/queries/dog_spec.rb
+++ b/spec/graphql/queries/dog_spec.rb
@@ -20,11 +20,17 @@ RSpec.describe 'dog query', type: :request do
     compare_gql_and_db_photos(first_gql_photo, photo)
   end
 
-  it 'raises exception if no dog with that id' do
+  it 'has an error if no dog with that id' do
     dog = create(:dog)
 
-    expect { post '/graphql', params: { query: query(id: dog.id + 1) } }
-    .to raise_error(ActiveRecord::RecordNotFound, "Couldn't find Dog with 'id'=#{dog.id + 1}")
+    post '/graphql', params: { query: query(id: dog.id + 1) }
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    error_message = json[:errors][0][:message]
+    expect(error_message).to eq("Couldn't find Dog with 'id'=#{dog.id + 1}")
+    
+    data = json[:data]
+    expect(data).to be_nil
   end
 
   def query(id:)

--- a/spec/graphql/queries/dogs_spec.rb
+++ b/spec/graphql/queries/dogs_spec.rb
@@ -109,37 +109,46 @@ RSpec.describe 'dogs query', type: :request do
     expect(data[3][:age]).to be_between(4, 10).inclusive
   end
 
-  it 'raises an exception when an incorrect range is passed to activityLevelRange' do
+  it 'has an error when an incorrect range is passed to activityLevelRange' do
     query = query('activityLevelRange: [2]')
 
     post '/graphql', params: { query: query }
 
     json = JSON.parse(response.body, symbolize_names: true)
-    error_message = json[:errors][0][:message]
 
+    error_message = json[:errors][0][:message]
     expect(error_message).to eq('Please provide an array with two integers for activityLevelRange.')
+
+    data = json[:data]
+    expect(data).to be_nil
   end
 
-  it 'raises an exception when an incorrect range is passed to weightRange' do
+  it 'has an error when an incorrect range is passed to weightRange' do
     query = query('weightRange: [40]')
 
     post '/graphql', params: { query: query }
 
     json = JSON.parse(response.body, symbolize_names: true)
+    
     error_message = json[:errors][0][:message]
-
     expect(error_message).to eq('Please provide an array with two integers for weightRange.')
+
+    data = json[:data]
+    expect(data).to be_nil
   end
 
-  it 'raises an exception when an incorrect range is passed to ageRange' do
+  it 'has an error when an incorrect range is passed to ageRange' do
     query = query('ageRange: [2]')
 
     post '/graphql', params: { query: query }
 
     json = JSON.parse(response.body, symbolize_names: true)
-    error_message = json[:errors][0][:message]
 
+    error_message = json[:errors][0][:message]
     expect(error_message).to eq('Please provide an array with two integers or floating point numbers for ageRange.')
+
+    data = json[:data]
+    expect(data).to be_nil
   end
 
   def query(argument)

--- a/spec/graphql/queries/user_spec.rb
+++ b/spec/graphql/queries/user_spec.rb
@@ -25,11 +25,17 @@ RSpec.describe "user query", type: :request do
     compare_gql_and_db_photos(first_gql_photo, photo)
   end
 
-  it 'raises exception if no user with that id' do
+  it 'has an error if no user with that id' do
     user = create(:user)
 
-    expect { post '/graphql', params: { query: query(id: user.id + 1) } }
-    .to raise_error(ActiveRecord::RecordNotFound, "Couldn't find User with 'id'=#{user.id + 1}")
+    post '/graphql', params: { query: query(id: user.id + 1) }
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    error_message = json[:errors][0][:message]
+    expect(error_message).to eq("Couldn't find User with 'id'=#{user.id + 1}")
+    
+    data = json[:data]
+    expect(data).to be_nil
   end
 
   def query(id:)


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Rescue  ActiveRecord::RecordNotFound and raise GraphQL::ExecutionError in user / dog queries (was returning 404 with no body -- fixed)

**The following checks have been completed:**
 - [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
 - [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
 - [x] Merged in the latest master to my branch with `git pull origin master` & resolved merge conflicts
 - [x] Ran `rails db:migrate`
 - [x] Ran the test suite - all tests are passing (or maybe skipped)
 - [x] Checked affected endpoints in Postman / GraphiQL
 - [x] Updated README for changes (new endpoints, new gems, etc)