### PR TITLE
Google geocoding api service

### DIFF
--- a/app/services/google_geocoding_api_service.rb
+++ b/app/services/google_geocoding_api_service.rb
@@ -1,0 +1,34 @@
+class GoogleGeocodingApiService
+  attr_reader :location_string
+
+  def initialize(input_hash = {})
+    @location_string = input_hash[:location_string]
+  end
+
+  def geocode
+    uri_path = '/maps/api/geocode/json'
+    Rails.logger.debug "Making Google geocoding API call (#{@location_string})"
+    location_hash = fetch_json_data(uri_path, address: @location_string)
+    check_and_raise_error(location_hash)
+    location_hash
+  end
+
+  private
+
+  def conn
+    @conn ||= Faraday.new(:url => 'https://maps.googleapis.com') do |faraday|
+      faraday.adapter Faraday.default_adapter
+      faraday.params['key'] = ENV['GOOGLE_MAPS_API_KEY']
+    end
+  end
+
+  def fetch_json_data(uri_path, params = {})
+    response = conn.get uri_path, params
+    JSON.parse response.body, symbolize_names: true
+  end
+
+  def check_and_raise_error(response)
+    error_message = response[:error_message]
+    raise "#{self.class} error: #{error_message}" if error_message
+  end
+end

--- a/spec/cassettes/google_geocoding_api/geocode_bad_api_key.yml
+++ b/spec/cassettes/google_geocoding_api/geocode_bad_api_key.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=1331%2017th%20St,%20Denver,%20CO%2080202&key=<GOOGLE_MAPS_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 04 Sep 2019 22:50:19 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=5
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "error_message" : "The provided API key is invalid.",
+           "results" : [],
+           "status" : "REQUEST_DENIED"
+        }
+    http_version: 
+  recorded_at: Wed, 04 Sep 2019 22:50:17 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/google_geocoding_api/geocode_good_response.yml
+++ b/spec/cassettes/google_geocoding_api/geocode_good_response.yml
@@ -1,0 +1,123 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=1331%2017th%20St,%20Denver,%20CO%2080202&key=<GOOGLE_MAPS_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 04 Sep 2019 22:29:24 GMT
+      Expires:
+      - Wed, 04 Sep 2019 22:29:34 GMT
+      Cache-Control:
+      - public, max-age=10
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '580'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=47
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "1331",
+                       "short_name" : "1331",
+                       "types" : [ "street_number" ]
+                    },
+                    {
+                       "long_name" : "17th Street",
+                       "short_name" : "17th St",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Central",
+                       "short_name" : "Central",
+                       "types" : [ "neighborhood", "political" ]
+                    },
+                    {
+                       "long_name" : "Denver",
+                       "short_name" : "Denver",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Denver County",
+                       "short_name" : "Denver County",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "Colorado",
+                       "short_name" : "CO",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "United States",
+                       "short_name" : "US",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "80202",
+                       "short_name" : "80202",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "1331 17th St, Denver, CO 80202, USA",
+                 "geometry" : {
+                    "location" : {
+                       "lat" : 39.75113810000001,
+                       "lng" : -104.996928
+                    },
+                    "location_type" : "ROOFTOP",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 39.75248708029151,
+                          "lng" : -104.9955790197085
+                       },
+                       "southwest" : {
+                          "lat" : 39.74978911970851,
+                          "lng" : -104.9982769802915
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJo13jHFF5bIcRtibnkeRc7Oc",
+                 "plus_code" : {
+                    "compound_code" : "Q223+F6 Denver, Colorado, United States",
+                    "global_code" : "85FQQ223+F6"
+                 },
+                 "types" : [ "street_address" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Wed, 04 Sep 2019 22:29:24 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/google_geocoding_api/geocode_no_results.yml
+++ b/spec/cassettes/google_geocoding_api/geocode_no_results.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=skjaljkfdaljda&key=<GOOGLE_MAPS_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 04 Sep 2019 22:44:33 GMT
+      Expires:
+      - Wed, 04 Sep 2019 22:44:43 GMT
+      Cache-Control:
+      - public, max-age=10
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '65'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=332
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [],
+           "status" : "ZERO_RESULTS"
+        }
+    http_version: 
+  recorded_at: Wed, 04 Sep 2019 22:44:31 GMT
+recorded_with: VCR 5.0.0

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,7 +15,9 @@ VCR.configure do |config|
   config.cassette_library_dir = 'spec/cassettes'
   config.hook_into :webmock
   config.configure_rspec_metadata!
-  config.filter_sensitive_data('<GOOGLE_PLACES_API_KEY>') { ENV['GOOGLE_PLACES_API_KEY'] }
+  config.filter_sensitive_data('<GOOGLE_MAPS_API_KEY>') { ENV['GOOGLE_MAPS_API_KEY'] }
+  config.filter_sensitive_data('<AWS_ACCESS_KEY_ID>') { ENV['AWS_ACCESS_KEY_ID'] }
+  config.filter_sensitive_data('<AWS_SECRET_ACCESS_KEY>') { ENV['AWS_SECRET_ACCESS_KEY'] }
   config.default_cassette_options = { record: :new_episodes }
 end
 

--- a/spec/services/google_geocoding_api_service_spec.rb
+++ b/spec/services/google_geocoding_api_service_spec.rb
@@ -34,4 +34,16 @@ RSpec.describe GoogleGeocodingApiService do
       expect(api_response).to eq(expected)
     end
   end
+
+  it '#geocode throws error if bad API key' do
+    VCR.use_cassette('google_geocoding_api/geocode_bad_api_key', record: :new_episodes) do
+      location_string = '1331 17th St, Denver, CO 80202'
+      service = GoogleGeocodingApiService.new(location_string: location_string)
+
+      stub_const('ENV', {'GOOGLE_MAPS_API_KEY' => 'blah'})
+
+      expect { service.geocode }
+      .to raise_error(RuntimeError, 'GoogleGeocodingApiService error: The provided API key is invalid.')
+    end
+  end
 end

--- a/spec/services/google_geocoding_api_service_spec.rb
+++ b/spec/services/google_geocoding_api_service_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe GoogleGeocodingApiService do
+  it 'initializes with a location_string' do
+    location_string = '1331 17th St, Denver, CO 80202'
+    service = GoogleGeocodingApiService.new(location_string: location_string)
+
+    expect(service.location_string).to eq(location_string)
+  end
+
+  it '#geocode returns API response, which includes lat and long' do
+    VCR.use_cassette('google_geocoding_api/geocode_good_response', record: :new_episodes) do
+      location_string = '1331 17th St, Denver, CO 80202'
+      service = GoogleGeocodingApiService.new(location_string: location_string)
+
+      api_response = service.geocode
+      location = api_response[:results].first[:geometry][:location]
+      expect(location[:lat]).to be_within(0.001).of(39.75113810000001)
+      expect(location[:lng]).to be_within(0.001).of(-104.996928)
+    end
+  end
+end

--- a/spec/services/google_geocoding_api_service_spec.rb
+++ b/spec/services/google_geocoding_api_service_spec.rb
@@ -19,4 +19,19 @@ RSpec.describe GoogleGeocodingApiService do
       expect(location[:lng]).to be_within(0.001).of(-104.996928)
     end
   end
+
+  it '#geocode has no results if bad location_string' do
+    VCR.use_cassette('google_geocoding_api/geocode_no_results', record: :new_episodes) do
+      location_string = 'skjaljkfdaljda'
+      service = GoogleGeocodingApiService.new(location_string: location_string)
+
+      api_response = service.geocode
+      expected = {
+        results: [],
+        status: "ZERO_RESULTS"
+      }
+
+      expect(api_response).to eq(expected)
+    end
+  end
 end


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Adds `GoogleGeocodingApiService` and `#geocode`. Takes in a string for a location and returns an API response that includes the latitude and longitude (resolves #38)
 - Adds VCR cassette filters of sensitive ENV vars

**The following checks have been completed:**
 - [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
 - [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
 - [x] Merged in the latest master to my branch with `git pull origin master` & resolved merge conflicts
 - [x] Ran `rails db:migrate`
 - [x] Ran the test suite - all tests are passing (or maybe skipped)
 - [x] Checked affected endpoints in Postman / GraphiQL
 - [x] Updated README for changes (new endpoints, new gems, etc)

**Notes:**
 - I added the Google Maps API key to both Heroku apps and CircleCI, but you'll need to add it to your own `config/application.yml` file as well.