### PR TITLE
Latlong Hook

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -2,4 +2,31 @@ class Location < ApplicationRecord
   belongs_to :user
 
   validates_presence_of :zip_code
+
+  before_save :update_latlong
+
+  private
+
+  def update_latlong
+    location = request_new_latlong
+    self.lat = location[:lat]
+    self.long = location[:lng]
+  end
+
+  def request_new_latlong
+    response = google_geocoding_api_service.geocode
+    response[:results].first[:geometry][:location]
+  end
+
+  def google_geocoding_api_service
+    GoogleGeocodingApiService.new(location_string: location_string)
+  end
+
+  def location_string
+    location_string = ''
+    location_string += "#{street_address}, " if street_address
+    location_string += "#{city}, "           if city
+    location_string += "#{state} "           if state
+    location_string += zip_code              if zip_code
+  end
 end

--- a/spec/cassettes/before_save_location_hook_create.yml
+++ b/spec/cassettes/before_save_location_hook_create.yml
@@ -1,0 +1,125 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=1331%2017th%20Street,%20Denver,%20CO%2080202&key=<GOOGLE_MAPS_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 05 Sep 2019 19:26:46 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=29
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "1331",
+                       "short_name" : "1331",
+                       "types" : [ "street_number" ]
+                    },
+                    {
+                       "long_name" : "17th Street",
+                       "short_name" : "17th St",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Central",
+                       "short_name" : "Central",
+                       "types" : [ "neighborhood", "political" ]
+                    },
+                    {
+                       "long_name" : "Denver",
+                       "short_name" : "Denver",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Denver County",
+                       "short_name" : "Denver County",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "Colorado",
+                       "short_name" : "CO",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "United States",
+                       "short_name" : "US",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "80202",
+                       "short_name" : "80202",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "1331 17th St, Denver, CO 80202, USA",
+                 "geometry" : {
+                    "location" : {
+                       "lat" : 39.75113810000001,
+                       "lng" : -104.996928
+                    },
+                    "location_type" : "ROOFTOP",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 39.75248708029151,
+                          "lng" : -104.9955790197085
+                       },
+                       "southwest" : {
+                          "lat" : 39.74978911970851,
+                          "lng" : -104.9982769802915
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJo13jHFF5bIcRtibnkeRc7Oc",
+                 "plus_code" : {
+                    "compound_code" : "Q223+F6 Denver, Colorado, United States",
+                    "global_code" : "85FQQ223+F6"
+                 },
+                 "types" : [ "street_address" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 05 Sep 2019 19:26:45 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/before_save_location_hook_update.yml
+++ b/spec/cassettes/before_save_location_hook_update.yml
@@ -1,0 +1,116 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=15330%20East%20120th%20Place,%20Commerce%20City,%20CO%2080022&key=<GOOGLE_MAPS_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 05 Sep 2019 19:26:58 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=24
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "15330",
+                       "short_name" : "15330",
+                       "types" : [ "street_number" ]
+                    },
+                    {
+                       "long_name" : "East 120th Place",
+                       "short_name" : "E 120th Pl",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Commerce City",
+                       "short_name" : "Commerce City",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Adams County",
+                       "short_name" : "Adams County",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "Colorado",
+                       "short_name" : "CO",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "United States",
+                       "short_name" : "US",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "80022",
+                       "short_name" : "80022",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "15330 E 120th Pl, Commerce City, CO 80022, USA",
+                 "geometry" : {
+                    "location" : {
+                       "lat" : 39.9157166,
+                       "lng" : -104.7692923
+                    },
+                    "location_type" : "RANGE_INTERPOLATED",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 39.9170655802915,
+                          "lng" : -104.7679433197085
+                       },
+                       "southwest" : {
+                          "lat" : 39.9143676197085,
+                          "lng" : -104.7706412802915
+                       }
+                    }
+                 },
+                 "place_id" : "Ei4xNTMzMCBFIDEyMHRoIFBsLCBDb21tZXJjZSBDaXR5LCBDTyA4MDAyMiwgVVNBIhsSGQoUChIJAY8qVrpubIcRh0YLdtHJU24Q4nc",
+                 "types" : [ "street_address" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 05 Sep 2019 19:26:57 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/users_query_location_create.yml
+++ b/spec/cassettes/users_query_location_create.yml
@@ -1,0 +1,125 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=1331%2017th%20Street,%20Denver,%20CO%2080202&key=<GOOGLE_MAPS_API_KEY>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 05 Sep 2019 19:54:11 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=381
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "1331",
+                       "short_name" : "1331",
+                       "types" : [ "street_number" ]
+                    },
+                    {
+                       "long_name" : "17th Street",
+                       "short_name" : "17th St",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Central",
+                       "short_name" : "Central",
+                       "types" : [ "neighborhood", "political" ]
+                    },
+                    {
+                       "long_name" : "Denver",
+                       "short_name" : "Denver",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Denver County",
+                       "short_name" : "Denver County",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "Colorado",
+                       "short_name" : "CO",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "United States",
+                       "short_name" : "US",
+                       "types" : [ "country", "political" ]
+                    },
+                    {
+                       "long_name" : "80202",
+                       "short_name" : "80202",
+                       "types" : [ "postal_code" ]
+                    }
+                 ],
+                 "formatted_address" : "1331 17th St, Denver, CO 80202, USA",
+                 "geometry" : {
+                    "location" : {
+                       "lat" : 39.75113810000001,
+                       "lng" : -104.996928
+                    },
+                    "location_type" : "ROOFTOP",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 39.75248708029151,
+                          "lng" : -104.9955790197085
+                       },
+                       "southwest" : {
+                          "lat" : 39.74978911970851,
+                          "lng" : -104.9982769802915
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJo13jHFF5bIcRtibnkeRc7Oc",
+                 "plus_code" : {
+                    "compound_code" : "Q223+F6 Denver, Colorado, United States",
+                    "global_code" : "85FQQ223+F6"
+                 },
+                 "types" : [ "street_address" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 05 Sep 2019 19:54:09 GMT
+recorded_with: VCR 5.0.0

--- a/spec/cassettes/users_query_location_create.yml
+++ b/spec/cassettes/users_query_location_create.yml
@@ -21,7 +21,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Thu, 05 Sep 2019 19:54:11 GMT
+      - Thu, 05 Sep 2019 20:18:12 GMT
       Pragma:
       - no-cache
       Expires:
@@ -39,7 +39,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Server-Timing:
-      - gfet4t7; dur=381
+      - gfet4t7; dur=44
       Alt-Svc:
       - quic=":443"; ma=2592000; v="46,43,39"
       Transfer-Encoding:
@@ -121,5 +121,5 @@ http_interactions:
            "status" : "OK"
         }
     http_version: 
-  recorded_at: Thu, 05 Sep 2019 19:54:09 GMT
+  recorded_at: Thu, 05 Sep 2019 20:18:11 GMT
 recorded_with: VCR 5.0.0

--- a/spec/graphql/queries/user_spec.rb
+++ b/spec/graphql/queries/user_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe 'user query', type: :request do
     dogs = create_list(:dog, 2, user: user)
     create(:photo, photoable: dogs.first)
     photo = create(:photo, photoable: user)
-    location = create(:location, user: user)
 
     post '/graphql', params: { query: query(id: user.id) }
 
@@ -24,9 +23,6 @@ RSpec.describe 'user query', type: :request do
 
     first_gql_photo = data[:photos].first
     compare_gql_and_db_photos(first_gql_photo, photo)
-
-    gql_location = data[:location]
-    compare_gql_and_db_locations(gql_location, location)
   end
 
   it 'has an error if no user with that id' do
@@ -52,9 +48,6 @@ RSpec.describe 'user query', type: :request do
           }
           photos {
             #{photo_type_attributes}
-          }
-          location {
-            #{location_type_attributes}
           }
         }
       }

--- a/spec/graphql/queries/users_spec.rb
+++ b/spec/graphql/queries/users_spec.rb
@@ -2,44 +2,44 @@ require 'rails_helper'
 
 RSpec.describe 'users query', type: :request do
   it 'returns all users' do
-    users = create_list(:user, 3)
-    dogs = create_list(:dog, 2, user: users.first)
-    photo = create(:photo, photoable: users.first)
-
     VCR.use_cassette('users_query_location_create') do
-      @location = Location.create!(
+      users = create_list(:user, 3)
+      dogs = create_list(:dog, 2, user: users.first)
+      photo = create(:photo, photoable: users.first)
+
+      location = Location.create!(
         user: users.first,
         street_address: '1331 17th Street',
         city: 'Denver',
         state: 'CO',
         zip_code: '80202'
       )
+
+      post '/graphql', params: { query: query }
+
+      json = JSON.parse(response.body, symbolize_names: true)
+      data = json[:data][:users]
+
+      expect(data.count).to eq(3)
+
+      first_gql_user = data.first
+      first_db_user = users.first
+      compare_gql_and_db_users(first_gql_user, first_db_user)
+
+      gql_dogs = first_gql_user[:dogs]
+      expect(gql_dogs.count).to eq(2)
+
+      first_gql_dog = gql_dogs.first
+      first_db_dog = dogs.first
+      compare_gql_and_db_dogs(first_gql_dog, first_db_dog)
+
+      gql_photos = first_gql_user[:photos]
+      expect(gql_photos.count).to eq(1)
+      compare_gql_and_db_photos(gql_photos.first, photo)
+
+      gql_location = first_gql_user[:location]
+      compare_gql_and_db_locations(gql_location, location)
     end
-
-    post '/graphql', params: { query: query }
-
-    json = JSON.parse(response.body, symbolize_names: true)
-    data = json[:data][:users]
-
-    expect(data.count).to eq(3)
-
-    first_gql_user = data.first
-    first_db_user = users.first
-    compare_gql_and_db_users(first_gql_user, first_db_user)
-
-    gql_dogs = first_gql_user[:dogs]
-    expect(gql_dogs.count).to eq(2)
-
-    first_gql_dog = gql_dogs.first
-    first_db_dog = dogs.first
-    compare_gql_and_db_dogs(first_gql_dog, first_db_dog)
-
-    gql_photos = first_gql_user[:photos]
-    expect(gql_photos.count).to eq(1)
-    compare_gql_and_db_photos(gql_photos.first, photo)
-
-    gql_location = first_gql_user[:location]
-    compare_gql_and_db_locations(gql_location, @location)
   end
 
   def query

--- a/spec/graphql/queries/users_spec.rb
+++ b/spec/graphql/queries/users_spec.rb
@@ -5,7 +5,16 @@ RSpec.describe 'users query', type: :request do
     users = create_list(:user, 3)
     dogs = create_list(:dog, 2, user: users.first)
     photo = create(:photo, photoable: users.first)
-    location = create(:location, user: users.first)
+
+    VCR.use_cassette('user_query_location_create') do
+      @location = Location.create!(
+        user: users.first,
+        street_address: '1331 17th Street',
+        city: 'Denver',
+        state: 'CO',
+        zip_code: '80202'
+      )
+    end
 
     post '/graphql', params: { query: query }
 
@@ -30,7 +39,7 @@ RSpec.describe 'users query', type: :request do
     compare_gql_and_db_photos(gql_photos.first, photo)
 
     gql_location = first_gql_user[:location]
-    compare_gql_and_db_locations(gql_location, location)
+    compare_gql_and_db_locations(gql_location, @location)
   end
 
   def query

--- a/spec/graphql/queries/users_spec.rb
+++ b/spec/graphql/queries/users_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'users query', type: :request do
     dogs = create_list(:dog, 2, user: users.first)
     photo = create(:photo, photoable: users.first)
 
-    VCR.use_cassette('user_query_location_create') do
+    VCR.use_cassette('users_query_location_create') do
       @location = Location.create!(
         user: users.first,
         street_address: '1331 17th Street',

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -13,13 +13,15 @@ RSpec.describe Location, type: :model do
     before :each do
       user = create(:user)
 
-      @location = Location.create!(
-        user: user,
-        street_address: '1331 17th Street',
-        city: 'Denver',
-        state: 'CO',
-        zip_code: '80202'
-      )
+      VCR.use_cassette('before_save_location_hook_create') do
+        @location = Location.create!(
+          user: user,
+          street_address: '1331 17th Street',
+          city: 'Denver',
+          state: 'CO',
+          zip_code: '80202'
+        )
+      end
     end
 
     it 'updates lat/long on model create' do
@@ -28,15 +30,17 @@ RSpec.describe Location, type: :model do
     end
 
     it 'updates lat/long on model update' do
-      @location.update(
-        street_address: '15330 East 120th Place',
-        city: 'Commerce City',
-        state: 'CO',
-        zip_code: '80022'
-      )
+      VCR.use_cassette('before_save_location_hook_update') do
+        @location.update(
+          street_address: '15330 East 120th Place',
+          city: 'Commerce City',
+          state: 'CO',
+          zip_code: '80022'
+        )
+      end
 
-      expect(location.lat).to be_within(0.001).of(39.915366)
-      expect(location.long).to be_within(0.001).of(-104.808407)
+      expect(@location.lat).to be_within(0.001).of(39.915366)
+      expect(@location.long).to be_within(0.001).of(-104.769292)
     end
   end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -9,22 +9,26 @@ RSpec.describe Location, type: :model do
     it { should validate_presence_of :zip_code }
   end
 
-  describe 'instance methods' do
-    it '#update_latlong' do
+  describe 'hooks' do
+    before :each do
       user = create(:user)
 
-      location = create(:location,
+      @location = Location.create!(
         user: user,
         street_address: '1331 17th Street',
         city: 'Denver',
         state: 'CO',
         zip_code: '80202'
       )
+    end
 
-      expect(location.lat).to be_within(0.001).of(39.751138)
-      expect(location.long).to be_within(0.001).of(-104.996928)
+    it 'updates lat/long on model create' do
+      expect(@location.lat).to be_within(0.001).of(39.751138)
+      expect(@location.long).to be_within(0.001).of(-104.996928)
+    end
 
-      location.update(
+    it 'updates lat/long on model update' do
+      @location.update(
         street_address: '15330 East 120th Place',
         city: 'Commerce City',
         state: 'CO',

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -8,4 +8,31 @@ RSpec.describe Location, type: :model do
   describe 'validations' do
     it { should validate_presence_of :zip_code }
   end
+
+  describe 'instance methods' do
+    it '#update_latlong' do
+      user = create(:user)
+
+      location = create(:location,
+        user: user,
+        street_address: '1331 17th Street',
+        city: 'Denver',
+        state: 'CO',
+        zip_code: '80202'
+      )
+
+      expect(location.lat).to be_within(0.001).of(39.751138)
+      expect(location.long).to be_within(0.001).of(-104.996928)
+
+      location.update(
+        street_address: '15330 East 120th Place',
+        city: 'Commerce City',
+        state: 'CO',
+        zip_code: '80022'
+      )
+
+      expect(location.lat).to be_within(0.001).of(39.915366)
+      expect(location.long).to be_within(0.001).of(-104.808407)
+    end
+  end
 end


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - This PR adds a before_save hook to the Location model that will update the lat/long of the resource upon being created or updated
- Adds spec for Location model before_save hook
- Adds cassettes for API calls in specs

Resolves #45 

**The following checks have been completed:**
 - [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
 - [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
 - [x] Merged in the latest master to my branch with `git pull origin master` & resolved merge conflicts
 - [x] Ran `rails db:migrate`
 - [x] Ran the test suite - all tests are passing (or maybe skipped)
 - [x] Checked affected endpoints in Postman / GraphiQL
 - [x] Updated README for changes (new endpoints, new gems, etc)