### PR TITLE
User Can Log Out

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,13 @@ Filters may be used in any combination. For fields where only a single value is 
 
 #### dog(id: <ID>)
 
-Returns a single dog having the specified ID. *ID argument is required.*
+Returns a single dog having the specified ID. *id: argument is required.*
 
 ### Mutations
 
 Mutations are requests to modify resources in the database.
 
-#### authenticateUser
+#### authenticateUser(auth: <AuthenticationInputType>, apiKey: <String>)
 
 Finds or creates a user in the database. Returns a CurrentUserType object, as well as a boolean attribute `new`, based on whether or not the user was found or created. Required arguments include:
 * apiKey - String (used to ensure that requests only come from the Express app -- not random HTTP requests)
@@ -211,6 +211,32 @@ Example of expected response:
         "email": "bobsmithiii@bs.com"
       },
       "new": true
+    }
+  }
+}
+```
+
+#### logOutUser(googleToken: <String>)
+
+Logs out a user. A successful request returns a `message` attribute. *googleToken: argument is required.*
+
+Example request:
+```
+mutation {
+  logOutUser(
+    googleToken: "1asdaa123-55FFaafaf-24SAF"
+  ) {
+    message
+  }
+}
+```
+
+Expected response:
+```
+{
+  "data": {
+    "logOutUser": {
+      "message": "User has been logged out"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -216,16 +216,15 @@ Example of expected response:
 }
 ```
 
-#### logOutUser(googleToken: <String>)
+#### logOutUser
 
-Logs out a user. A successful request returns a `message` attribute. *googleToken: argument is required.*
+Logs out a user based on the specified `google_token` query parameter. A successful request returns a `message` attribute.
 
 Example request:
 ```
 mutation {
-  logOutUser(
-    googleToken: "1asdaa123-55FFaafaf-24SAF"
-  ) {
+  logOutUser
+  {
     message
   }
 }

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -4,7 +4,7 @@ module Mutations
 
     def boot_unauthenticated_user
       unless context[:current_user]
-        raise GraphQL::ExecutionError, 'Unauthorized'
+        raise GraphQL::ExecutionError, 'Unauthorized - a valid google_token query parameter is required'
       end
     end
   end

--- a/app/graphql/mutations/log_out_user.rb
+++ b/app/graphql/mutations/log_out_user.rb
@@ -1,0 +1,21 @@
+module Mutations
+  class LogOutUser < BaseMutation
+    null true
+
+    argument :google_token, String, required: true
+
+    field :message, String, null: true
+
+    def resolve(google_token:)
+      user = User.find_by(google_token: google_token)
+
+      if user
+        user.update(google_token: nil)
+
+        { message: 'User has been logged out' }
+      else
+        raise GraphQL::ExecutionError, 'No user found with that Google token'
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/log_out_user.rb
+++ b/app/graphql/mutations/log_out_user.rb
@@ -2,20 +2,14 @@ module Mutations
   class LogOutUser < BaseMutation
     null true
 
-    argument :google_token, String, required: true
-
     field :message, String, null: true
 
-    def resolve(google_token:)
-      user = User.find_by(google_token: google_token)
+    def resolve
+      boot_unauthenticated_user
 
-      if user
-        user.update(google_token: nil)
+      context[:current_user].update(google_token: nil)
 
-        { message: 'User has been logged out' }
-      else
-        raise GraphQL::ExecutionError, 'No user found with that Google token'
-      end
+      { message: 'User has been logged out' }
     end
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,5 +1,6 @@
 module Types
   class MutationType < Types::BaseObject
     field :authenticate_user, mutation: Mutations::AuthenticateUser
+    field :log_out_user, mutation: Mutations::LogOutUser
   end
 end

--- a/spec/graphql/mutations/authenticate_user_spec.rb
+++ b/spec/graphql/mutations/authenticate_user_spec.rb
@@ -2,21 +2,15 @@ require 'rails_helper'
 
 RSpec.describe 'authenticate user mutation', type: :request do
   before :each do
-    @existing_user = create(:user,
-      first_name: 'Bob',
-      last_name: 'Smith III',
-      email: 'bobsmithiii@bs.com',
-      google_token: 'thisisthethirdbesttoken'
-    )
-
+    @existing_user = create(:user)
     @api_key = ENV['EXPRESS_API_KEY']
   end
 
   describe 'with a valid API key and an existing user in the database' do
     it 'finds and returns the user' do
-      query = authenticate_user_query(@existing_user, @api_key)
+      mutation = authenticate_user_mutation(@existing_user, @api_key)
 
-      post '/graphql', params: { query: query }
+      post '/graphql', params: { query: mutation }
 
       json = JSON.parse(response.body, symbolize_names: true)
 
@@ -41,9 +35,9 @@ RSpec.describe 'authenticate user mutation', type: :request do
         google_token: 'thisisthesecondbesttoken',
       )
 
-      query = authenticate_user_query(user, @api_key)
+      mutation = authenticate_user_mutation(user, @api_key)
 
-      post '/graphql', params: { query: query }
+      post '/graphql', params: { query: mutation }
 
       json = JSON.parse(response.body, symbolize_names: true)
 
@@ -63,9 +57,9 @@ RSpec.describe 'authenticate user mutation', type: :request do
     it 'it does not return an authenticated user' do
       invalid_api_key = 'invalidkey'
 
-      query = authenticate_user_query(@existing_user, invalid_api_key)
+      mutation = authenticate_user_mutation(@existing_user, invalid_api_key)
 
-      post '/graphql', params: { query: query }
+      post '/graphql', params: { query: mutation }
 
       json = JSON.parse(response.body, symbolize_names: true)
 
@@ -77,7 +71,7 @@ RSpec.describe 'authenticate user mutation', type: :request do
     end
   end
 
-  def authenticate_user_query(user, api_key)
+  def authenticate_user_mutation(user, api_key)
     "mutation {
       authenticateUser(
         apiKey: \"#{api_key}\",

--- a/spec/graphql/mutations/log_out_user_spec.rb
+++ b/spec/graphql/mutations/log_out_user_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'log out user mutation', type: :request do
 
     mutation = log_out_user_mutation(user)
 
-    post '/graphql', params: { query: mutation }
+    post '/graphql', params: { google_token: user.google_token, query: mutation }
 
     json = JSON.parse(response.body, symbolize_names: true)
 
@@ -25,7 +25,7 @@ RSpec.describe 'log out user mutation', type: :request do
 
     mutation = log_out_user_mutation(user)
 
-    post '/graphql', params: { query: mutation }
+    post '/graphql', params: { google_token: user.google_token, query: mutation }
 
     json = JSON.parse(response.body, symbolize_names: true)
 
@@ -33,14 +33,12 @@ RSpec.describe 'log out user mutation', type: :request do
     error_message = json[:errors][0][:message]
 
     expect(data).to be_nil
-    expect(error_message).to eq('No user found with that Google token')
+    expect(error_message).to eq('Unauthorized - a valid google_token query parameter is required')
   end
 
   def log_out_user_mutation(user)
     "mutation {
-      logOutUser(
-        googleToken: \"#{user.google_token}\"
-      ) {
+      logOutUser {
         message
       }
     }"

--- a/spec/graphql/mutations/log_out_user_spec.rb
+++ b/spec/graphql/mutations/log_out_user_spec.rb
@@ -1,1 +1,48 @@
 require 'rails_helper'
+
+RSpec.describe 'log out user mutation', type: :request do
+  it 'logs out a user that is logged in' do
+    user = create(:user)
+
+    mutation = log_out_user_mutation(user)
+
+    post '/graphql', params: { query: mutation }
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    data = json[:data][:logOutUser]
+
+    expect(data[:message]).to eq('User has been logged out')
+  end
+
+  it 'does not log out a user that is not logged in' do
+    user = double(
+      first_name: 'Bob',
+      last_name: 'Smith IV',
+      email: 'bobsmithiv@bs.com',
+      google_token: 'notloggedin',
+    )
+
+    mutation = log_out_user_mutation(user)
+
+    post '/graphql', params: { query: mutation }
+
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    data = json[:data][:logOutUser]
+    error_message = json[:errors][0][:message]
+
+    expect(data).to be_nil
+    expect(error_message).to eq('No user found with that Google token')
+  end
+
+  def log_out_user_mutation(user)
+    "mutation {
+      logOutUser(
+        googleToken: \"#{user.google_token}\"
+      ) {
+        message
+      }
+    }"
+  end
+end


### PR DESCRIPTION
**Changes proposed in this pull request:**
This PR adds a mutation that allows current users to log out. When a valid googleToken is passed in, the User is found, and their google_token in the database is set to nil. An invalid googleToken will trigger an error message.

 - Refactors authenticatedUser spec
 - Adds logOutMutation with spec
 - Adds logOutMutation to GraphQL schema
 - Adds documentation for logOutUser mutation
 - UPDATE: refactors logOutUser mutation to leverage BaseMutation::boot_unauthenticated_user

Resolves #54 

**The following checks have been completed:**
 - [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
 - [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
 - [x] Merged in the latest master to my branch with `git pull origin master` & resolved merge conflicts
 - [x] Ran `rails db:migrate`
 - [x] Ran the test suite - all tests are passing (or maybe skipped)
 - [x] Checked affected endpoints in Postman / GraphiQL
 - [x] Updated README for changes (new endpoints, new gems, etc)