### PR TITLE
Generate token

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Returns a single user having the specified ID. *ID argument is required.*
 
 #### currentUser
 
-Returns an authenticated user, based on the specified googleToken. Returns null if no user has the specified googleToken. Has additional information not available in the basic user query, such as lastName, email and location.
+Returns an authenticated user, based on the specified token. Returns null if no user has the specified token. Has additional information not available in the basic user query, such as lastName, email and location.
 
 #### dogs(<filters>)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _CrowdHound_ utilizes [GraphQL](https://graphql.org/). All queries are made to a
 
 ### Authentication
 
-To make queries or mutations as a logged-in user, include that user's Google token as a `google_token` query param.
+To make queries or mutations as a logged-in user, include that user's token as a `token` query param.
 
 ### Object Types
 
@@ -77,7 +77,6 @@ Object types are templates for resources in the database.  Each object type has 
 * firstName - String (required)
 * lastName - String (required)
 * email - String (required)
-* googleToken - String (required)
 
 #### LocationInputType Attributes
 
@@ -210,7 +209,6 @@ mutation {
       firstName: "Bob",
       lastName: "Smith III",
       email: "bobsmithiii@bs.com"
-      token: "googletoken"
     }
   ) {
     currentUser {
@@ -220,6 +218,7 @@ mutation {
       email
     }
     new
+    token
   }
 }
 ```
@@ -236,6 +235,7 @@ Example of expected response:
         "email": "bobsmithiii@bs.com"
       },
       "new": true
+      "token": "6f5f36f48e637a04e428ba12b930f301"
     }
   }
 }
@@ -243,7 +243,7 @@ Example of expected response:
 
 #### logOutUser
 
-Logs out a user based on the specified `google_token` query parameter. A successful request returns a `message` attribute.
+Logs out a user based on the specified `token` query parameter. A successful request returns a `message` attribute.
 
 Example request:
 ```
@@ -268,7 +268,7 @@ Expected response:
 
 #### createLocation(location: <LocationInputType>)
 
-Adds a location for the user with the `google_token` specified in the query parameter. Requires a LocationInputType argument. A successful response returns a LocationType object.
+Adds a location for the user with the `token` specified in the query parameter. Requires a LocationInputType argument. A successful response returns a LocationType object.
 
 Example request:
 ```
@@ -310,7 +310,7 @@ Example of expected response:
 
 #### createDog(dog: <DogInputType>)
 
-Creates a dog in the database for the current user (based on the `google_token` in the params). Requires a DogInputType argument. Returns a DogType object.
+Creates a dog in the database for the current user (based on the `token` in the params). Requires a DogInputType argument. Returns a DogType object.
 
 Example request:
 ```

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -16,9 +16,9 @@ class GraphqlController < ApplicationController
   private
 
   def current_user
-    google_token = params[:google_token]
+    token = params[:token]
 
-    User.find_by(google_token: google_token)
+    User.find_by(token: token)
   end
 
   # Handle form data, JSON body, or a blank value

--- a/app/graphql/mutations/authenticate_user.rb
+++ b/app/graphql/mutations/authenticate_user.rb
@@ -7,6 +7,7 @@ module Mutations
 
     field :current_user, Types::CurrentUserType, null: true
     field :new, Boolean, null: true
+    field :token, String, null: false
 
     def resolve(auth:, api_key:)
       unless api_key == ENV['EXPRESS_API_KEY']
@@ -19,13 +20,15 @@ module Mutations
 
       user.new_record? ? new = true : new = false
 
+      token = SecureRandom.hex
+
       user.first_name = auth[:first_name]
       user.last_name = auth[:last_name]
-      user.google_token = auth[:google_token]
+      user.token = token
 
       user.save
 
-      { current_user: user, new: new }
+      { current_user: user, new: new, token: token }
     end
   end
 end

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -4,7 +4,7 @@ module Mutations
 
     def boot_unauthenticated_user
       unless context[:current_user]
-        raise GraphQL::ExecutionError, 'Unauthorized - a valid google_token query parameter is required'
+        raise GraphQL::ExecutionError, 'Unauthorized - a valid token query parameter is required'
       end
     end
   end

--- a/app/graphql/mutations/log_out_user.rb
+++ b/app/graphql/mutations/log_out_user.rb
@@ -7,7 +7,7 @@ module Mutations
     def resolve
       boot_unauthenticated_user
 
-      context[:current_user].update(google_token: nil)
+      context[:current_user].update(token: nil)
 
       { message: 'User has been logged out' }
     end

--- a/app/graphql/types/authentication_input.rb
+++ b/app/graphql/types/authentication_input.rb
@@ -3,6 +3,5 @@ module Types
     argument :first_name, String, required: true
     argument :last_name, String, required: true
     argument :email, String, required: true
-    argument :google_token, String, required: true
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -22,7 +22,7 @@ module Types
     end
 
     field :current_user, Types::CurrentUserType, null: true,
-      description: 'Get information for the current user (based on the googleToken in the params)' do
+      description: 'Get information for the current user (based on the token in the params)' do
     end
 
     def current_user

--- a/db/migrate/20190909192849_rename_google_token_in_users.rb
+++ b/db/migrate/20190909192849_rename_google_token_in_users.rb
@@ -1,0 +1,5 @@
+class RenameGoogleTokenInUsers < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :users, :google_token, :token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_06_225333) do
+ActiveRecord::Schema.define(version: 2019_09_09_192849) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,8 +66,8 @@ ActiveRecord::Schema.define(version: 2019_09_06_225333) do
     t.text "long_desc"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "google_token"
-    t.index ["google_token"], name: "index_users_on_google_token"
+    t.string "token"
+    t.index ["token"], name: "index_users_on_token"
   end
 
   add_foreign_key "dogs", "users"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     email { Faker::Internet.unique.email }
     short_desc { Faker::Hipster.sentence(word_count: 12) }
     long_desc { Faker::Hipster.paragraph(sentence_count: 8) }
-    google_token { Faker::Alphanumeric.alphanumeric(number: 10) }
+    token { Faker::Alphanumeric.alphanumeric(number: 10) }
   end
 end

--- a/spec/graphql/mutations/authenticate_user_spec.rb
+++ b/spec/graphql/mutations/authenticate_user_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'authenticateUser mutation', type: :request do
         first_name: 'Bob',
         last_name: 'Smith II',
         email: 'bobsmithii@bs.com',
-        google_token: 'thisisthesecondbesttoken',
+        token: 'thisisthesecondbesttoken',
       )
 
       mutation = authenticate_user_mutation(user, @api_key)
@@ -79,7 +79,6 @@ RSpec.describe 'authenticateUser mutation', type: :request do
           firstName: \"#{user.first_name}\"
           lastName: \"#{user.last_name}\"
           email: \"#{user.email}\"
-          googleToken: \"#{user.google_token}\"
         }
       ) {
         currentUser {

--- a/spec/graphql/mutations/authenticate_user_spec.rb
+++ b/spec/graphql/mutations/authenticate_user_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe 'authenticateUser mutation', type: :request do
       )
 
       expect(data[:new]).to eq(false)
+
+      expect(data[:token]).to eq(@existing_user.reload.token)
     end
   end
 
@@ -50,6 +52,8 @@ RSpec.describe 'authenticateUser mutation', type: :request do
       )
 
       expect(data[:new]).to eq(true)
+
+      expect(data[:token]).to eq(User.last.token)
     end
   end
 
@@ -85,6 +89,7 @@ RSpec.describe 'authenticateUser mutation', type: :request do
           #{current_user_type_attributes}
         }
         new
+        token
       }
     }"
   end

--- a/spec/graphql/mutations/create_dog_spec.rb
+++ b/spec/graphql/mutations/create_dog_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'createDog mutation', type: :request do
     )
 
     params = {
-      google_token: user.google_token,
+      token: user.token,
       query: create_dog_mutation(dog_template)
     }
 
@@ -42,7 +42,7 @@ RSpec.describe 'createDog mutation', type: :request do
     )
 
     params = {
-      google_token: 'not a real google token',
+      token: 'not a real token',
       query: create_dog_mutation(dog_template)
     }
 
@@ -54,7 +54,7 @@ RSpec.describe 'createDog mutation', type: :request do
     error_message = json[:errors][0][:message]
 
     expect(data).to be_nil
-    expect(error_message).to eq('Unauthorized - a valid google_token query parameter is required')
+    expect(error_message).to eq('Unauthorized - a valid token query parameter is required')
 
     expect(Dog.count).to eq(0)
   end

--- a/spec/graphql/mutations/create_location_spec.rb
+++ b/spec/graphql/mutations/create_location_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'createLocation mutation', type: :request do
     @existing_user = create(:user)
   end
 
-  describe 'with a valid Google token and valid location' do
+  describe 'with a valid token and valid location' do
     it 'creates a new location' do
       VCR.use_cassette('create_location_mutation_spec/valid_location') do
         mutation = create_valid_location_mutation
@@ -26,7 +26,7 @@ RSpec.describe 'createLocation mutation', type: :request do
     end
   end
 
-  describe 'with a valid Google token and invalid location' do
+  describe 'with a valid token and invalid location' do
     it 'does not create a new location' do
       VCR.use_cassette('create_location_mutation_spec/invalid_location') do
         mutation = create_invalid_location_mutation
@@ -47,7 +47,7 @@ RSpec.describe 'createLocation mutation', type: :request do
     end
   end
 
-  describe 'with an invalid Google token' do
+  describe 'with an invalid token' do
     it 'does not create a new location' do
       mutation = create_valid_location_mutation
 

--- a/spec/graphql/mutations/create_location_spec.rb
+++ b/spec/graphql/mutations/create_location_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'createLocation mutation', type: :request do
         mutation = create_valid_location_mutation
 
         post '/graphql', params: {
-                           google_token: @existing_user.google_token,
+                           token: @existing_user.token,
                            query: mutation
                          }
 
@@ -32,7 +32,7 @@ RSpec.describe 'createLocation mutation', type: :request do
         mutation = create_invalid_location_mutation
 
         post '/graphql', params: {
-                           google_token: @existing_user.google_token,
+                           token: @existing_user.token,
                            query: mutation
                          }
         json = JSON.parse(response.body, symbolize_names: true)
@@ -52,7 +52,7 @@ RSpec.describe 'createLocation mutation', type: :request do
       mutation = create_valid_location_mutation
 
       post '/graphql', params: {
-                         google_token: 'thisisthesecondbesttoken',
+                         token: 'thisisthesecondbesttoken',
                          query: mutation
                        }
 
@@ -62,7 +62,7 @@ RSpec.describe 'createLocation mutation', type: :request do
       error_message = json[:errors][0][:message]
 
       expect(data).to be_nil
-      expect(error_message).to eq('Unauthorized - a valid google_token query parameter is required')
+      expect(error_message).to eq('Unauthorized - a valid token query parameter is required')
       expect(Location.count).to eq(0)
     end
   end

--- a/spec/graphql/mutations/log_out_user_spec.rb
+++ b/spec/graphql/mutations/log_out_user_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'logOutUser mutation', type: :request do
 
     mutation = log_out_user_mutation
 
-    post '/graphql', params: { google_token: user.google_token, query: mutation }
+    post '/graphql', params: { token: user.token, query: mutation }
 
     json = JSON.parse(response.body, symbolize_names: true)
 
@@ -20,12 +20,12 @@ RSpec.describe 'logOutUser mutation', type: :request do
       first_name: 'Bob',
       last_name: 'Smith IV',
       email: 'bobsmithiv@bs.com',
-      google_token: 'notloggedin',
+      token: 'notloggedin',
     )
 
     mutation = log_out_user_mutation
 
-    post '/graphql', params: { google_token: user.google_token, query: mutation }
+    post '/graphql', params: { token: user.token, query: mutation }
 
     json = JSON.parse(response.body, symbolize_names: true)
 
@@ -33,7 +33,7 @@ RSpec.describe 'logOutUser mutation', type: :request do
     error_message = json[:errors][0][:message]
 
     expect(data).to be_nil
-    expect(error_message).to eq('Unauthorized - a valid google_token query parameter is required')
+    expect(error_message).to eq('Unauthorized - a valid token query parameter is required')
   end
 
   def log_out_user_mutation

--- a/spec/graphql/queries/current_user_spec.rb
+++ b/spec/graphql/queries/current_user_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'current_user query', type: :request do
 
       params = { 
         query: query,
-        google_token: user.google_token
+        token: user.token
       }
 
       post '/graphql', params: params

--- a/spec/graphql/queries/dog_spec.rb
+++ b/spec/graphql/queries/dog_spec.rb
@@ -116,6 +116,6 @@ RSpec.describe 'dog query', type: :request do
   end
 
   def make_authenticated_post_request(query)
-    post '/graphql', params: { google_token: @current_user.google_token, query: query }
+    post '/graphql', params: { token: @current_user.token, query: query }
   end
 end

--- a/spec/graphql/queries/dogs_spec.rb
+++ b/spec/graphql/queries/dogs_spec.rb
@@ -355,6 +355,6 @@ RSpec.describe 'dogs query', type: :request do
   end
 
   def make_authenticated_post_request(query)
-    post '/graphql', params: { google_token: @current_user.google_token, query: query }
+    post '/graphql', params: { token: @current_user.token, query: query }
   end
 end


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Change `authenticateUser` mutation to generate a random token instead of using Google's refresh token for authentication of future requests. The token is returned from the request and should be saved to the client's cookies.
 - Rename column of `User` from `google_token` to `token`

**The following checks have been completed:**
 - [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
 - [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
 - [x] Merged in the latest master to my branch with `git pull origin master` & resolved merge conflicts
 - [x] Ran `rails db:migrate`
 - [x] Ran the test suite - all tests are passing (or maybe skipped)
 - [x] Checked affected endpoints in Postman / GraphiQL
 - [x] Updated README for changes (new endpoints, new gems, etc)

**Notes:**
 - Includes a DB migration -- will need to run on your machine (as well as Heroku if CI isn't automatically doing it)