### PR TITLE
Update authenticateUser mutation

### DIFF
--- a/app/graphql/mutations/authenticate_user.rb
+++ b/app/graphql/mutations/authenticate_user.rb
@@ -18,14 +18,16 @@ module Mutations
         email: auth[:email]
       )
 
-      user.new_record? ? new = true : new = false
+      if user.new_record?
+        user.first_name = auth[:first_name]
+        user.last_name = auth[:last_name]
+        new = true
+      else
+        new = false
+      end
 
       token = SecureRandom.hex
-
-      user.first_name = auth[:first_name]
-      user.last_name = auth[:last_name]
       user.token = token
-
       user.save
 
       { current_user: user, new: new, token: token }


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Updates authenticateUser mutation to set first_name/last_name only if the User is newly created

**The following checks have been completed:**
 - [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
 - [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
 - [x] Merged in the latest master to my branch with `git pull origin master` & resolved merge conflicts
 - [x] Ran `rails db:migrate`
 - [x] Ran the test suite - all tests are passing (or maybe skipped)
 - [x] Checked affected endpoints in Postman / GraphiQL
 - [N/A] Updated README for changes (new endpoints, new gems, etc)
