### PR TITLE
Decrypt base64 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Example of expected response:
 
 #### createPhoto(photo: <PhotoInputType>)
 
-Uploads the photo from the `file` query param to an AWS S3 bucket and creates a photo resource in the database for the current user or the current user's dog. Whitelisted image file types include: bmp, jpeg, jpg, tiff, png. Requires a PhotoInputType argument. Returns a PhotoType object.
+Decrypts and uploads a base-64 encoded photo from the `file` query param to an AWS S3 bucket and creates a photo resource in the database for the current user or the current user's dog. Whitelisted image file types include: bmp, jpeg, jpg, tiff, png. Requires a PhotoInputType argument. Returns a PhotoType object.
 
 Example request:
 ```

--- a/app/graphql/mutations/create_photo.rb
+++ b/app/graphql/mutations/create_photo.rb
@@ -19,17 +19,24 @@ module Mutations
 
       raw_file = context[:file]
 
+      Rails.logger.debug "********************************** raw file = " + raw_file
+      
       if !raw_file
         raise GraphQL::ExecutionError, 'Image must be provided as a "file" query parameter'
       end
-
+      
       meta, encoded_file = raw_file.split(',')
-
+      Rails.logger.debug "********************************** meta = " + meta
+      Rails.logger.debug "********************************** encoded file = " + encoded_file
+      
       before_semicolon = meta.split(';')[0]
       file_ext = before_semicolon.split('/')[1]
       file_name = "#{SecureRandom.hex}.#{file_ext}"
+      Rails.logger.debug "********************************** file name = " + file_name
 
       decoded_file = Base64.decode64(encoded_file)
+
+      Rails.logger.debug "********************************** decoded file = " + decoded_file
 
       raise_error_if_not_image_file(file_ext)
 

--- a/app/graphql/mutations/create_photo.rb
+++ b/app/graphql/mutations/create_photo.rb
@@ -1,3 +1,5 @@
+require 'base64'
+
 module Mutations
   class CreatePhoto < BaseMutation
     null true
@@ -15,21 +17,26 @@ module Mutations
 
       photoable = get_photoable(current_user, photoable_type, photoable_id)
 
-      file = context[:file]
+      raw_file = context[:file]
 
-      if !file
+      if !raw_file
         raise GraphQL::ExecutionError, 'Image must be provided as a "file" query parameter'
       end
 
-      file_ext = file.tempfile.path.split(".")[1]
+      meta, encoded_file = raw_file.split(',')
+
+      before_semicolon = meta.split(';')[0]
+      file_ext = before_semicolon.split('/')[1]
       file_name = "#{SecureRandom.hex}.#{file_ext}"
+
+      decoded_file = Base64.decode64(encoded_file)
 
       raise_error_if_not_image_file(file_ext)
 
       s3.put_object(
         bucket: ENV['AWS_BUCKET'],
         key: file_name,
-        body: file
+        body: decoded_file
       )
 
       new_photo = create_photo_resource(photoable, photo[:caption], file_name)

--- a/app/graphql/mutations/create_photo.rb
+++ b/app/graphql/mutations/create_photo.rb
@@ -19,24 +19,17 @@ module Mutations
 
       raw_file = context[:file]
 
-      Rails.logger.debug "********************************** raw file = " + raw_file
-      
       if !raw_file
         raise GraphQL::ExecutionError, 'Image must be provided as a "file" query parameter'
       end
       
       meta, encoded_file = raw_file.split(',')
-      Rails.logger.debug "********************************** meta = " + meta
-      Rails.logger.debug "********************************** encoded file = " + encoded_file
       
       before_semicolon = meta.split(';')[0]
       file_ext = before_semicolon.split('/')[1]
       file_name = "#{SecureRandom.hex}.#{file_ext}"
-      Rails.logger.debug "********************************** file name = " + file_name
 
       decoded_file = Base64.decode64(encoded_file)
-
-      Rails.logger.debug "********************************** decoded file = " + decoded_file
 
       raise_error_if_not_image_file(file_ext)
 

--- a/spec/graphql/mutations/create_photo_spec.rb
+++ b/spec/graphql/mutations/create_photo_spec.rb
@@ -1,11 +1,14 @@
 require 'rails_helper'
+require 'base64'
 
 RSpec.describe 'createPhoto mutation', type: :request do
   describe 'as an authenticated user' do
     before(:each) do
       @user = create(:user)
-  
-      @file = Rack::Test::UploadedFile.new(File.open(File.join(Rails.root, '/spec/fixtures/images/dog.jpg')))
+
+      file = Rack::Test::UploadedFile.new(File.open(File.join(Rails.root, '/spec/fixtures/images/dog.jpg')))
+
+      @encoded_file = 'data:image/png;base64,' + Base64.encode64( file.tempfile.read)
     end
 
     it 'creates a photo for the current_user' do
@@ -14,7 +17,7 @@ RSpec.describe 'createPhoto mutation', type: :request do
       params = {
         token: @user.token,
         query: create_photo_mutation(photo),
-        file: @file
+        file: @encoded_file
       }
 
       post '/graphql', params: params
@@ -35,10 +38,12 @@ RSpec.describe 'createPhoto mutation', type: :request do
 
       audio_file = Rack::Test::UploadedFile.new(File.open(File.join(Rails.root, '/spec/fixtures/images/audio.mp3')))
 
+      encoded_audio_file = 'data:audio/mp3;base64,' + Base64.encode64( audio_file.tempfile.read)
+
       params = {
         token: @user.token,
         query: create_photo_mutation(photo),
-        file: audio_file
+        file: encoded_audio_file
       }
 
       post '/graphql', params: params
@@ -82,7 +87,7 @@ RSpec.describe 'createPhoto mutation', type: :request do
       params = {
         token: @user.token,
         query: create_photo_mutation(photo),
-        file: @file
+        file: @encoded_file
       }
 
       post '/graphql', params: params
@@ -104,7 +109,7 @@ RSpec.describe 'createPhoto mutation', type: :request do
       params = {
         token: @user.token,
         query: create_photo_mutation(photo),
-        file: @file
+        file: @encoded_file
       }
 
       post '/graphql', params: params
@@ -128,7 +133,7 @@ RSpec.describe 'createPhoto mutation', type: :request do
       params = {
         token: @user.token,
         query: create_photo_mutation(photo),
-        file: @file
+        file: @encoded_file
       }
       
       post '/graphql', params: params
@@ -152,7 +157,7 @@ RSpec.describe 'createPhoto mutation', type: :request do
       params = {
         token: @user.token,
         query: create_photo_mutation(photo),
-        file: @file
+        file: @encoded_file
       }
 
       post '/graphql', params: params
@@ -175,7 +180,7 @@ RSpec.describe 'createPhoto mutation', type: :request do
       params = {
         token: @user.token,
         query: create_photo_mutation(photo),
-        file: @file
+        file: @encoded_file
       }
 
       post '/graphql', params: params

--- a/spec/graphql/mutations/create_photo_spec.rb
+++ b/spec/graphql/mutations/create_photo_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'createPhoto mutation', type: :request do
 
       file = Rack::Test::UploadedFile.new(File.open(File.join(Rails.root, '/spec/fixtures/images/dog.jpg')))
 
-      @encoded_file = 'data:image/png;base64,' + Base64.encode64( file.tempfile.read)
+      @encoded_file = 'data:image/png;base64,' + Base64.encode64(file.tempfile.read)
     end
 
     it 'creates a photo for the current_user' do


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Changes `createPhoto` mutation to accept a base64 encoded string instead of an image file

Related to user story #57 & #59 

**The following checks have been completed:**
 - [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
 - [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
 - [x] Merged in the latest master to my branch with `git pull origin master` & resolved merge conflicts
 - [x] Ran `rails db:migrate`
 - [x] Ran the test suite - all tests are passing (or maybe skipped)
 - [ ] Checked affected endpoints in Postman / GraphiQL
 - [x] Updated README for changes (new endpoints, new gems, etc)

**Note:**
Testing in Postman is not trivial anymore, since it requires encoding the file first.