### PR TITLE
Start chat mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,31 @@ Example of expected response:
 }
 ```
 
+#### startChat(userId: <id of user to start chat with>)
+
+Finds or creates a chatkit room (chat) between the current user (based on the specified `token` query parameter) and the user specified by id in the mutation's argument. A successful request returns a `roomId` attribute.
+
+Example request (for user 73):
+```
+mutation {
+  startChat(userId: 56)
+  {
+    roomId
+  }
+}
+```
+
+Expected response:
+```
+{
+  "data": {
+    "startChat": {
+      "roomId": "56-73"
+    }
+  }
+}
+```
+
 ## Local Installation
 
 ### Requirements

--- a/app/graphql/mutations/authenticate_user.rb
+++ b/app/graphql/mutations/authenticate_user.rb
@@ -34,9 +34,7 @@ module Mutations
 
       user.update(token: token)
 
-      unless user_chatkit_service.existing_chatkit_user
-        user_chatkit_service.create_chatkit_user
-      end
+      user_chatkit_service.find_or_create_chatkit_user
 
       { current_user: user, new: new, token: token }
     end

--- a/app/graphql/mutations/start_chat.rb
+++ b/app/graphql/mutations/start_chat.rb
@@ -1,0 +1,34 @@
+module Mutations
+  class StartChat < BaseMutation
+    null true
+
+    argument :user_id, String, required: true
+
+    field :message, String, null: true
+
+    def resolve(user_id:)
+      boot_unauthenticated_user
+
+      user = User.find_by(id: user_id)
+      unless user boot_unauthorized_user
+
+      participant_ids = [context[:current_user].id, user_id]
+
+      room_id = "#{participant_ids.min}-#{participant_ids.min}"
+
+      ChatkitService.connect.get_room({
+        id: room_id
+      })
+
+      # ChatkitService.connect.create_room({
+      #   id: room_id
+      #   creator_id: context[:current_user].id.to_s,
+      #   name: room_id,
+      #   user_ids: participant_ids.map(&:to_s),
+      #   private: true
+      # })
+
+      { message: "success" }
+    end
+  end
+end

--- a/app/graphql/mutations/start_chat.rb
+++ b/app/graphql/mutations/start_chat.rb
@@ -9,38 +9,16 @@ module Mutations
     def resolve(user_id:)
       boot_unauthenticated_user
 
-      current_user = context[:current_user]
-
       user = User.find_by(id: user_id)
       boot_unauthorized_user unless user
 
-      [current_user, user].each do |db_user|
+      [context[:current_user], user].each do |db_user|
         chatkit_service.find_or_create_chatkit_user(db_user)
       end
 
-      participant_ids = [current_user.id, user_id]
+      room = chatkit_service.find_or_create_room(user_id)
 
-      room_id = "#{participant_ids.min}-#{participant_ids.max}"
-
-      begin
-        ChatkitService.connect.get_room({
-          id: room_id
-        })
-      rescue => err
-        if err.error_description == 'The requested room does not exist'
-          ChatkitService.connect.create_room({
-            id: room_id,
-            creator_id: current_user.id.to_s,
-            name: room_id,
-            user_ids: participant_ids.map(&:to_s),
-            private: true
-          })
-        else
-          raise GraphQL::ExecutionError, err.message
-        end
-      end
-
-      { room_id: room_id }
+      { room_id: room[:body][:id] }
     end
 
     def chatkit_service

--- a/app/graphql/mutations/start_chat.rb
+++ b/app/graphql/mutations/start_chat.rb
@@ -2,33 +2,49 @@ module Mutations
   class StartChat < BaseMutation
     null true
 
-    argument :user_id, String, required: true
+    argument :user_id, Int, required: true
 
-    field :message, String, null: true
+    field :room_id, String, null: true
 
     def resolve(user_id:)
       boot_unauthenticated_user
 
+      current_user = context[:current_user]
+
       user = User.find_by(id: user_id)
-      unless user boot_unauthorized_user
+      boot_unauthorized_user unless user
 
-      participant_ids = [context[:current_user].id, user_id]
+      [current_user, user].each do |db_user|
+        chatkit_service.find_or_create_chatkit_user(db_user)
+      end
 
-      room_id = "#{participant_ids.min}-#{participant_ids.min}"
+      participant_ids = [current_user.id, user_id]
 
-      ChatkitService.connect.get_room({
-        id: room_id
-      })
+      room_id = "#{participant_ids.min}-#{participant_ids.max}"
 
-      # ChatkitService.connect.create_room({
-      #   id: room_id
-      #   creator_id: context[:current_user].id.to_s,
-      #   name: room_id,
-      #   user_ids: participant_ids.map(&:to_s),
-      #   private: true
-      # })
+      begin
+        ChatkitService.connect.get_room({
+          id: room_id
+        })
+      rescue => err
+        if err.error_description == 'The requested room does not exist'
+          ChatkitService.connect.create_room({
+            id: room_id,
+            creator_id: current_user.id.to_s,
+            name: room_id,
+            user_ids: participant_ids.map(&:to_s),
+            private: true
+          })
+        else
+          raise GraphQL::ExecutionError, err.message
+        end
+      end
 
-      { message: "success" }
+      { room_id: room_id }
+    end
+
+    def chatkit_service
+      chatkit_service ||= ChatkitService.new(context[:current_user])
     end
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -10,5 +10,7 @@ module Types
     field :destroy_dog, mutation: Mutations::DestroyDog
 
     field :create_photo, mutation: Mutations::CreatePhoto
+
+    field :start_chat, mutation: Mutations::StartChat
   end
 end

--- a/app/services/chatkit_service.rb
+++ b/app/services/chatkit_service.rb
@@ -12,9 +12,9 @@ class ChatkitService
     })
   end
 
-  def existing_chatkit_user
+  def existing_chatkit_user(user = @user)
     begin
-      conn.get_user({ id: @user.id.to_s })
+      conn.get_user({ id: user.id.to_s })
     rescue => err
       if err.error_description == 'The requested user does not exist'
         nil
@@ -24,12 +24,16 @@ class ChatkitService
     end
   end
 
-  def create_chatkit_user
-    response = conn.create_user({ id: @user.id.to_s, name: @user.first_name })
+  def create_chatkit_user(user = @user)
+    response = conn.create_user({ id: user.id.to_s, name: user.first_name })
 
     unless response[:status] == 201
       raise "Chatkit failed to create user. Response: #{response}"
     end
+  end
+
+  def find_or_create_chatkit_user(user = @user)
+    existing_chatkit_user(user) || create_chatkit_user(user)
   end
 
   def get_token
@@ -39,6 +43,8 @@ class ChatkitService
 
     auth_data.body[:access_token] # token_type: bearer
   end
+
+  private
 
   def conn
     self.class.connect

--- a/app/services/chatkit_service.rb
+++ b/app/services/chatkit_service.rb
@@ -50,12 +50,12 @@ class ChatkitService
     room_id = "#{participant_ids.min}-#{participant_ids.max}"
 
     begin
-      ChatkitService.connect.get_room({
+      conn.get_room({
         id: room_id
       })
     rescue => err
       if err.error_description == 'The requested room does not exist'
-        ChatkitService.connect.create_room({
+        conn.create_room({
           id: room_id,
           creator_id: @user.id.to_s,
           name: room_id,
@@ -71,6 +71,6 @@ class ChatkitService
   private
 
   def conn
-    self.class.connect
+    @conn ||= self.class.connect
   end
 end

--- a/app/services/chatkit_service.rb
+++ b/app/services/chatkit_service.rb
@@ -53,7 +53,6 @@ class ChatkitService
       ChatkitService.connect.get_room({
         id: room_id
       })
-      require 'pry'; binding.pry
     rescue => err
       if err.error_description == 'The requested room does not exist'
         ChatkitService.connect.create_room({

--- a/spec/graphql/mutations/start_chat_spec.rb
+++ b/spec/graphql/mutations/start_chat_spec.rb
@@ -45,6 +45,25 @@ RSpec.describe 'startChat mutation', type: :request do
   
       expect(gql_room_id_2).to eq(expected_room_id)
     end
+
+    it 'throws an error if there is no user with that id' do
+      user, other_user = create_list(:user, 2)
+
+      params = {
+        token: user.token,
+        query: start_chat_mutation(other_user.id + 1)
+      }
+  
+      post '/graphql', params: params
+  
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      error_message = json[:errors][0][:message]
+      expect(error_message).to eq('Unauthorized')
+      
+      data = json[:data][:startChat]
+      expect(data).to be_nil
+    end
   end
 
   describe 'as a visitor (not authenticated)' do

--- a/spec/graphql/mutations/start_chat_spec.rb
+++ b/spec/graphql/mutations/start_chat_spec.rb
@@ -19,6 +19,32 @@ RSpec.describe 'startChat mutation', type: :request do
   
       expect(gql_room_id).to eq(expected_room_id)
     end
+
+    it 'finds an existing chat between the current user and a particular user' do
+      user, other_user = create_list(:user, 2)
+
+      params = {
+        token: user.token,
+        query: start_chat_mutation(other_user.id)
+      }
+  
+      post '/graphql', params: params
+  
+      json1 = JSON.parse(response.body, symbolize_names: true)
+
+      gql_room_id_1 = json1[:data][:startChat][:roomId]
+      expected_room_id = "#{user.id.to_s}-#{other_user.id.to_s}"
+  
+      expect(gql_room_id_1).to eq(expected_room_id)
+
+      post '/graphql', params: params
+  
+      json2 = JSON.parse(response.body, symbolize_names: true)
+
+      gql_room_id_2 = json2[:data][:startChat][:roomId]
+  
+      expect(gql_room_id_2).to eq(expected_room_id)
+    end
   end
 
   describe 'as a visitor (not authenticated)' do

--- a/spec/graphql/mutations/start_chat_spec.rb
+++ b/spec/graphql/mutations/start_chat_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe 'startChat mutation', type: :request do
+  describe 'as an authenticated user' do
+    it "creates a new chat with a particular user (if there isn't one already)" do
+      user, other_user = create_list(:user, 2)
+
+      params = {
+        token: user.token,
+        query: start_chat_mutation(other_user.id)
+      }
+  
+      post '/graphql', params: params
+  
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      gql_room_id = json[:data][:startChat][:roomId]
+      expected_room_id = "#{user.id.to_s}-#{other_user.id.to_s}"
+  
+      expect(gql_room_id).to eq(expected_room_id)
+    end
+  end
+
+  describe 'as a visitor (not authenticated)' do
+    xit 'does not create a dog' do
+      dog_template = Dog.new(
+        name: 'Fluffy',
+        activity_level: 1,
+        weight: 10,
+        breed: 'Miniature Poodle',
+        birthdate: '2018/08/01',
+        short_desc: 'Playful little pup',
+        long_desc: 'What else could you possibly want to know?'
+      )
+  
+      params = {
+        token: 'not a real token',
+        query: start_chat_mutation(dog_template)
+      }
+  
+      post '/graphql', params: params
+  
+      json = JSON.parse(response.body, symbolize_names: true)
+  
+      data = json[:data][:createDog]
+      error_message = json[:errors][0][:message]
+  
+      expect(data).to be_nil
+      expect(error_message).to eq('Unauthorized - a valid token query parameter is required')
+  
+      expect(Dog.count).to eq(0)
+    end
+  end
+
+  def start_chat_mutation(user_id)
+    "mutation {
+      startChat(userId: #{user_id}) {
+        roomId
+      }
+    }"
+  end
+end

--- a/spec/graphql/mutations/start_chat_spec.rb
+++ b/spec/graphql/mutations/start_chat_spec.rb
@@ -22,33 +22,23 @@ RSpec.describe 'startChat mutation', type: :request do
   end
 
   describe 'as a visitor (not authenticated)' do
-    xit 'does not create a dog' do
-      dog_template = Dog.new(
-        name: 'Fluffy',
-        activity_level: 1,
-        weight: 10,
-        breed: 'Miniature Poodle',
-        birthdate: '2018/08/01',
-        short_desc: 'Playful little pup',
-        long_desc: 'What else could you possibly want to know?'
-      )
-  
+    it 'does not create a new chat' do
+      user, other_user = create_list(:user, 2)
+
       params = {
         token: 'not a real token',
-        query: start_chat_mutation(dog_template)
+        query: start_chat_mutation(other_user.id)
       }
   
       post '/graphql', params: params
   
       json = JSON.parse(response.body, symbolize_names: true)
   
-      data = json[:data][:createDog]
       error_message = json[:errors][0][:message]
-  
-      expect(data).to be_nil
       expect(error_message).to eq('Unauthorized - a valid token query parameter is required')
-  
-      expect(Dog.count).to eq(0)
+      
+      data = json[:data][:startChat]
+      expect(data).to be_nil
     end
   end
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Add `startChat` mutation, which either finds or creates a chatkit room between the current user and the user with the id provided as an argument.
 - Add `ChatkitService#find_or_create_chatkit_user ` and `ChatkitService#find_or_create_room `

Resolves #96 

**The following checks have been completed:**
 - [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
 - [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
 - [x] Merged in the latest master to my branch with `git pull origin master` & resolved merge conflicts
 - [x] Ran `rails db:migrate`
 - [x] Ran the test suite - all tests are passing (or maybe skipped)
 - [x] Checked affected endpoints in Postman / GraphiQL
 - [x] Updated README for changes (new endpoints, new gems, etc)