### PR TITLE
Chats query

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ To make queries or mutations as a logged-in user, include that user's token as a
 
 Object types are templates for resources in the database.  Each object type has a list of attributes that are available to return along with the object.
 
+#### ChatType Attributes
+
+* id - String (required)
+* unreadCount - Int
+* lastMessageAt - String
+* user - UserType
+
 #### CurrentUserType Attributes
 
 * id - ID (Int, required)
@@ -118,7 +125,7 @@ Object types are templates for resources in the database.  Each object type has 
 
 #### users
 
-Returns an array of all users with requested attributes.
+Returns an array of all UserType objects with requested attributes.
 
 Example request body:
 ```
@@ -182,15 +189,15 @@ Example of expected output:
 
 #### user(id: <ID>)
 
-Returns a single user having the specified ID. *ID argument is required.*
+Returns a single UserType object having the specified ID. *ID argument is required.*
 
 #### currentUser
 
-Returns an authenticated user, based on the specified token. Returns null if no user has the specified token. Has additional information not available in the basic user query, such as lastName, email and location.
+Returns an authenticated user (CurrentUserType object), based on the specified token. Returns null if no user has the specified token. Has additional information not available in the basic user query, such as lastName, email and location.
 
 #### dogs(<filters>)
 
-Returns a collection of dogs, with the option to filter by comma separated arguments. If the request is authenticated, the dogs are sorted by distance to the authenticated user.
+Returns an array of DogType objects, with the option to filter by comma separated arguments. If the request is authenticated, the dogs are sorted by distance to the authenticated user.
 
 Available arguments are:
 * activityLevelRange: <Array with two integer values, denoting the minimum and maximum acceptable activity level>
@@ -208,7 +215,11 @@ Filters may be used in any combination. For fields where only a single value is 
 
 #### dog(id: <ID>)
 
-Returns a single dog having the specified ID. *id: argument is required.*
+Returns a single DogType object having the specified ID. *id: argument is required.*
+
+#### chats
+
+If the request is authenticated (with a valid `token` query parameter), the request returns an array of ChatType objects that the current user is a part of. If the request is not authenticated, the request returns null.
 
 ### Mutations
 

--- a/app/graphql/types/chat_type.rb
+++ b/app/graphql/types/chat_type.rb
@@ -5,20 +5,6 @@ module Types
     field :last_message_at, String, null: true
     field :user, Types::UserType, null: true
 
-    # [
-    #   {
-    #     "id": "1",
-    #     "created_by_id": "user2",
-    #     "name": "mycoolroom",
-    #     "private": false,
-    #     "created_at": "2017-03-23T11:36:42Z",
-    #     "updated_at": "2017-03-23T11:36:42Z",
-    #     "member_user_ids":["user3", "user4"],
-    #     "unread_count": 1,
-    #     "last_message_at": "2017-03-23T11:36:42Z"
-    #   }
-    # ]
-    
     def user
       current_user = context[:current_user]
       

--- a/app/graphql/types/chat_type.rb
+++ b/app/graphql/types/chat_type.rb
@@ -1,0 +1,38 @@
+module Types
+  class ChatType < Types::BaseObject
+    field :id, String, null: false
+    field :unread_count, Int, null: true
+    field :last_message_at, String, null: true
+    field :user, Types::UserType, null: true
+
+    # [
+    #   {
+    #     "id": "1",
+    #     "created_by_id": "user2",
+    #     "name": "mycoolroom",
+    #     "private": false,
+    #     "created_at": "2017-03-23T11:36:42Z",
+    #     "updated_at": "2017-03-23T11:36:42Z",
+    #     "member_user_ids":["user3", "user4"],
+    #     "unread_count": 1,
+    #     "last_message_at": "2017-03-23T11:36:42Z"
+    #   }
+    # ]
+    
+    def user
+      current_user = context[:current_user]
+      
+      if current_user
+        chat_member_ids = object[:member_user_ids].map(&.to_i)
+
+        other_member_id = chat_member_ids.find do |member_id|
+          current_user.id != member_id
+        end
+
+        User.find(other_member_id)
+      else
+        nil
+      end
+    end
+  end
+end

--- a/app/graphql/types/chat_type.rb
+++ b/app/graphql/types/chat_type.rb
@@ -23,7 +23,7 @@ module Types
       current_user = context[:current_user]
       
       if current_user
-        chat_member_ids = object[:member_user_ids].map(&.to_i)
+        chat_member_ids = object[:member_user_ids].map(&:to_i)
 
         other_member_id = chat_member_ids.find do |member_id|
           current_user.id != member_id

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -55,5 +55,23 @@ module Types
         raise GraphQL::ExecutionError, e.message
       end
     end
+
+    # Chat Queries
+
+    field :chats, [Types::ChatType], null: false,
+      description: 'List all chats for the current user'
+
+    def chats
+      return unless context[:current_user]
+
+      chats = chatkit_service.list_chats
+      require 'pry'; binding.pry
+    end
+
+    private
+
+    def chatkit_service
+      @chatkit_service ||= ChatkitService.new(context[:current_user])
+    end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -58,14 +58,14 @@ module Types
 
     # Chat Queries
 
-    field :chats, [Types::ChatType], null: false,
+    field :chats, [Types::ChatType], null: true,
       description: 'List all chats for the current user'
 
     def chats
       return unless context[:current_user]
 
       chats = chatkit_service.list_chats
-      
+
       chats[:body]
     end
 

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -65,7 +65,8 @@ module Types
       return unless context[:current_user]
 
       chats = chatkit_service.list_chats
-      require 'pry'; binding.pry
+      
+      chats[:body]
     end
 
     private

--- a/app/services/chatkit_service.rb
+++ b/app/services/chatkit_service.rb
@@ -44,6 +44,24 @@ class ChatkitService
     auth_data.body[:access_token] # token_type: bearer
   end
 
+  def list_chats
+    conn.get_user_rooms({ id: @user.id.to_s })
+
+    # [
+    #   {
+    #     "id": "1",
+    #     "created_by_id": "user2",
+    #     "name": "mycoolroom",
+    #     "private": false,
+    #     "created_at": "2017-03-23T11:36:42Z",
+    #     "updated_at": "2017-03-23T11:36:42Z",
+    #     "member_user_ids":["user3", "user4"],
+    #     "unread_count": 1,
+    #     "last_message_at": "2017-03-23T11:36:42Z"
+    #   }
+    # ]
+  end
+
   def find_or_create_room(other_user_id)
     participant_ids = [@user.id, other_user_id]
 

--- a/spec/graphql/queries/chats_spec.rb
+++ b/spec/graphql/queries/chats_spec.rb
@@ -5,32 +5,40 @@ RSpec.describe 'chats query', type: :request do
     it 'returns all chats' do
       u1, u2, u3 = create_list(:user, 3)
 
+      params1 = {
+        token: u1.token,
+        query: start_chat_mutation(u2.id)
+      }
 
+      post '/graphql', params: params1
+
+      params2 = {
+        token: u1.token,
+        query: start_chat_mutation(u3.id)
+      }
+      
+      post '/graphql', params: params2
+      
+      params3 = {
+        token: u1.token,
+        query: query
+      }
+
+      post '/graphql', params: params3
   
-      # post '/graphql', params: {
-      #   token: u1.token
-      #   query: query
-      # }
-  
-      # json = JSON.parse(response.body, symbolize_names: true)
-      # data = json[:data][:users]
-  
-      # expect(data.count).to eq(3)
-  
-      # first_gql_user = data.first
-      # first_db_user = users.first
-      # compare_gql_and_db_users(first_gql_user, first_db_user)
-  
-      # gql_dogs = first_gql_user[:dogs]
-      # expect(gql_dogs.count).to eq(2)
-  
-      # first_gql_dog = gql_dogs.first
-      # first_db_dog = dogs.first
-      # compare_gql_and_db_dogs(first_gql_dog, first_db_dog)
-  
-      # gql_photos = first_gql_user[:photos]
-      # expect(gql_photos.count).to eq(1)
-      # compare_gql_and_db_photos(gql_photos.first, photo)
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      chats = json[:data][:chats]
+
+      expect(chats.count).to eq(2)
+
+      first_chat = chats[0]
+
+      expect(first_chat).to have_key(:id)
+      expect(first_chat).to have_key(:unreadCount)
+      expect(first_chat).to have_key(:lastMessageAt)
+
+      compare_gql_and_db_users(first_chat[:user], u2)
     end
   end
 
@@ -45,5 +53,13 @@ RSpec.describe 'chats query', type: :request do
         }
       }
     GQL
+  end
+
+  def start_chat_mutation(user_id)
+    "mutation {
+      startChat(userId: #{user_id}) {
+        roomId
+      }
+    }"
   end
 end

--- a/spec/graphql/queries/chats_spec.rb
+++ b/spec/graphql/queries/chats_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe 'chats query', type: :request do
+  describe 'as an authenticated user' do
+    it 'returns all chats' do
+      u1, u2, u3 = create_list(:user, 3)
+
+
+  
+      # post '/graphql', params: {
+      #   token: u1.token
+      #   query: query
+      # }
+  
+      # json = JSON.parse(response.body, symbolize_names: true)
+      # data = json[:data][:users]
+  
+      # expect(data.count).to eq(3)
+  
+      # first_gql_user = data.first
+      # first_db_user = users.first
+      # compare_gql_and_db_users(first_gql_user, first_db_user)
+  
+      # gql_dogs = first_gql_user[:dogs]
+      # expect(gql_dogs.count).to eq(2)
+  
+      # first_gql_dog = gql_dogs.first
+      # first_db_dog = dogs.first
+      # compare_gql_and_db_dogs(first_gql_dog, first_db_dog)
+  
+      # gql_photos = first_gql_user[:photos]
+      # expect(gql_photos.count).to eq(1)
+      # compare_gql_and_db_photos(gql_photos.first, photo)
+    end
+  end
+
+  def query
+    <<~GQL
+      query {
+        chats {
+          #{chat_type_attributes}
+          user {
+            #{user_type_attributes}
+          }
+        }
+      }
+    GQL
+  end
+end

--- a/spec/graphql/queries/chats_spec.rb
+++ b/spec/graphql/queries/chats_spec.rb
@@ -42,6 +42,22 @@ RSpec.describe 'chats query', type: :request do
     end
   end
 
+  describe 'as a visitor (without a valid api key)' do
+    it 'returns null' do
+      params = {
+        token: 'not a real token',
+        query: query
+      }
+
+      post '/graphql', params: params
+  
+      json = JSON.parse(response.body, symbolize_names: true)
+      
+      data = json[:data][:chats]
+      expect(data).to be_nil
+    end
+  end
+
   def query
     <<~GQL
       query {

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -212,3 +212,12 @@ def compare_gql_and_db_locations(graphql_location, db_location)
   expect(graphql_location[:lat]).to be_within(0.001).of(db_location.lat)
   expect(graphql_location[:long]).to be_within(0.001).of(db_location.long)
 end
+
+## ChatType
+def chat_type_attributes
+  '
+  id
+  unreadCount
+  lastMessageAt
+  '
+end


### PR DESCRIPTION
**Changes proposed in this pull request:**
 - Adds `chats` query to `QueryType` -- returns a list of all chats that the current user is a part of (or null if not authenticated)
 - Adds `ChatType` and test helper method `chat_type_attributes`
 - Adds `ChatkitService#list_chats`

Resolves #104, related to user story #100 

**The following checks have been completed:**
 - [x] Tested my new feature(s) as well as any feasible edge cases (if possible)
 - [x] Checked `coverage/index.html` - did not add any new code that's not covered by testing (if possible)
 - [x] Merged in the latest master to my branch with `git pull origin master` & resolved merge conflicts
 - [x] Ran `rails db:migrate`
 - [x] Ran the test suite - all tests are passing (or maybe skipped)
 - [x] Checked affected endpoints in Postman / GraphiQL
 - [x] Updated README for changes (new endpoints, new gems, etc)